### PR TITLE
Use outDir for tsc build option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.*
 *.p12
 *.key
 *.mobileprovision
+build

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,12 @@
 {
-    "compilerOptions": {
-      "target": "es5",
-      "lib": ["es2015", "esnext.asynciterable"],
-      "jsx": "react-native",
-      "strict": true,
-      "noUnusedLocals": true,
-      "noUnusedParameters": true,
-      "types": [
-        "jest"
-      ]
-    }
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es2015", "esnext.asynciterable"],
+    "jsx": "react-native",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": ["jest"],
+    "outDir": "build"
   }
+}


### PR DESCRIPTION
* Use `outDir` option for tsc build output to remove `.js` compilation code from codebase. This will compile TypeScript into a `build/` directory which is git ignored. This keeps the TypeScript compilation output out of the `src/` folder and version control. No need to see it!